### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See it live [CFP List](https://cfplist.herokuapp.com/)
 This project loves contributions, and we've made it as easy to contribute as possible.
 
 1. Fork the project
-2. Clone the fork to your computer: `git clone https://github.com/{yourGithubName}/cfp-list` (don't forget to replace {yourGithubName} with your username).
+2. Clone the fork to your computer: `git clone https://github.com/{yourGitHubName}/cfp-list` (don't forget to replace {yourGitHubName} with your username).
 3. Run:
 ```sh
 cd cfp-list

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,7 +162,7 @@ function App() {
             ></img>
           </vwc-menu-item>
           <vwc-menu-item
-            text="Source on Github"
+            text="Source on GitHub"
             onClick={() => link('https://github.com/noam-honig/cfp-list')}
           >
             <vwc-icon slot="meta" name="github-mono" size="-4" />

--- a/src/components/github-signin.tsx
+++ b/src/components/github-signin.tsx
@@ -14,7 +14,7 @@ export default function GithubSignIn({ signedIn }: { signedIn: VoidFunction }) {
       })
       .catch((err: any) => alert(err.message))
   }, [])
-  return <span>waiting for github sign in....</span>
+  return <span>waiting for GitHub sign in....</span>
 }
 
 let staticGithubSignInUrl = ''
@@ -28,7 +28,7 @@ export function GithubSignInButton({ signedIn }: { signedIn: VoidFunction }) {
 
   return (
     <vwc-menu-item
-      text="Sign in with github"
+      text="Sign in with GitHub"
       onClick={() => signInWithGithub(signedIn)}
     >
       <vwc-icon name="github-mono" slot="meta" size="-4" />


### PR DESCRIPTION
In their documentation, GitHub has the G and the H capitalized (see, e.g., https://docs.github.com/en/get-started/quickstart/hello-world).

This patch fixes the capitalization in the README.md file and the user-facing strings of the UI.